### PR TITLE
Fix for Chiotellis et al. paper details button

### DIFF
--- a/papers.html
+++ b/papers.html
@@ -311,11 +311,11 @@
       <p></p>
 
       <p>
-        <button class="btn btn-secondary" type="button" data-toggle="collapse" data-target="#deWit20240213" aria-expanded="false" aria-controls="deWit20240213">
+        <button class="btn btn-secondary" type="button" data-toggle="collapse" data-target="#Chiotellis20240529" aria-expanded="false" aria-controls="Chiotellis20240529">
           Details
         </button>
       </p>
-            <div class="collapse" id="https://arxiv.org/abs/2403.19743">
+            <div class="collapse" id="Chiotellis20240529">
         <div class="card card-body">
           <p><b>Authors: </b> Chiotellis A.; Zapartas E.; Meyer D. M.-A.</p>
           <p><b>Access: </b> <a href="https://arxiv.org/abs/2403.19743" target="_blank">arXiv:2403.19743</a> || <a href="https://ui.adsabs.harvard.edu/abs/2024arXiv240319743C/abstract" target="_blank">NASA ADS</a> 


### PR DESCRIPTION
The button had a link to the deWit et al. 2024 paper details. This fixes it so it correctly links to the Chiotellis+2024 details