### PR TITLE
Update error page to POSYDON

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,114 +1,115 @@
 <!DOCTYPE html>
 <html lang="en">
-        <head><meta charset="utf-8">
-                <meta http-equiv="X-UA-Compatible" content="IE=edge">
-                <meta name="viewport" content="width=device-width,initial-scale=1">
-                <title>
-                        Error 404 - POSYDON
-                </title>
-                <meta name="robots" content="noindex, follow">
-                <meta name="generator" content="Publii Open-Source CMS for Static Site">
-                <link rel="alternate" type="application/atom+xml" href="https://POSYDON-code.github.io/feed.xml">
-                <link rel="alternate" type="application/json" href="https://POSYDON-code.github.io/feed.json">
-                <meta property="og:title" content="POSYDON">
-                <meta property="og:site_name" content="POSYDON">
-                <meta property="og:description" content="">
-                <meta property="og:url" content="https://POSYDON-code.github.io/">
-                <meta property="og:type" content="website">
-                <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
-                <style>h1,h2,h3,h4,h5,h6,.btn,[type=button],[type=submit],button,.navbar .navbar__menu li,.navbar_mobile_sidebar .navbar__menu li,.feed__author,.post__tag,.post__share>a span,.post__nav-link>span,.footer{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"}body,h1,.h1,blockquote,.search__input,.author__name,.author__info>p,.feed__item h2,.post__nav-link{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"}</style>
-                <link rel="stylesheet" href="https://POSYDON-code.github.io/assets/css/style.css?v=cc87cb8806c844f0646558fe70d5c5d1">
-                <script type="application/ld+json">
-                        {"@context":"http://schema.org",
-                         "@type":"Organization",
-                         "name":"POSYDON",
-                         "url":"https://POSYDON-code.github.io/"
-                        }
-                </script>
-                <script src="https://POSYDON-code.github.io/assets/js/ls.parent-fit.min.js?v=1c78585e2a70398fe95085061942fd37"></script>
-                <script async src="https://POSYDON-code.github.io/assets/js/lazysizes.min.js?v=149ff45fc6c2f13e892e438a58abb77f"></script>
-        </head>
-        <body>
-                <div class="site-container">
-                        <header class="top" id="js-header">
-                                <a class="logo" href="https://POSYDON-code.github.io/">POSYDON</a>
-                                <div class="search">
-                                        <div class="search__overlay js-search-overlay">
-                                                <div class="search__overlay-inner">
-                                                        <form action="https://POSYDON-code.github.io/search.html" class="search__form">
-                                                                <input class="search__input js-search-input" type="search" name="q" placeholder="search..." autofocus="autofocus">
-                                                        </form>
-                                                        <button class="search__close js-search-close" aria-label="Close">Close</button>
-                                                </div>
-                                        </div>
-                                        <button class="search__btn js-search-btn" aria-label="Search">
-                                                <svg role="presentation" focusable="false">
-                                                        <use xlink:href="https://POSYDON-code.github.io/assets/svg/svg-map.svg#search"/>
-                                                </svg>
-                                        </button>
-                                </div>
-                        </header>
-                        <main>
-                                <article class="post">
-                                        <div class="hero">
-                                                <header class="hero__content">
-                                                        <div class="wrapper">
-                                                                <h1>404</h1>
-                                                                <p>Page not found</p>
-                                                        </div>
-                                                </header>
-                                        </div>
-                                        <div class="wrapper post__entry">
-                                                <p>
-                                                        The page you were looking for appears to have been moved, deleted or does not exist. You could go back to where you were or head straight to our home page.</p>
-                                                <p>
-                                                        <svg width="1.041em" height="0.416em" aria-hidden="true">
-                                                                <use xlink:href="https://POSYDON-code.github.io/assets/svg/svg-map.svg#arrow-prev"/>
-                                                        </svg>
-                                                        <a href="https://POSYDON-code.github.io/" class="readmore">Go home</a>
-                                                </p>
-                                        </div>
-                                </article>
-                        </main>
-                        <footer class="footer">
-                                <div class="footer__copyright">
-                                        Powered by <a href="https://getpublii.com" target="_blank" rel="nofollow noopener noreferrer">Publii Static CMS</a>
-                                </div>
-                                <button class="footer__bttop js-footer__bttop" aria-label="Back to top">
-                                        <svg>
-                                                <title>
-                                                        Back to top
-                                                </title>
-                                                <use xlink:href="https://POSYDON-code.github.io/assets/svg/svg-map.svg#toparrow"/>
-                                        </svg>
-                                </button>
-                        </footer>
-                </div>
-                <script>
-                        window.publiiThemeMenuConfig = {
-                                mobileMenuMode: 'sidebar',
-                                animationSpeed: 300,
-                                submenuWidth: 'auto',
-                                doubleClickTime: 500,
-                                mobileMenuExpandableSubmenus: true,
-                                relatedContainerForOverlayMenuSelector: '.top',
-                        };
-                </script>
-                <script defer="defer" src="https://POSYDON-code.github.io/assets/js/scripts.min.js?v=f56b13ba141d95ea2a0b7aab75ca9528"></script>
-                <script>
-                        var lazyFeaturedImage=function lazyFeaturedImage(){
-                                var b=document.querySelectorAll(".hero__image-img");
-                                for(var a=0;a<b.length;a++){
-                                        var c=b[a];
-                                        c.addEventListener(
-                                                "lazyloaded",function(f){
-                                                        var d=f.target.parentNode;
-                                                        d.classList.add("hero__image--overlay")
-                                                }
-                                        )
-                                }
-                        };
-                        lazyFeaturedImage();
-                </script>
-        </body>
+  <head><meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>
+      Error 404 - POSYDON
+    </title>
+    <meta name="robots" content="noindex, follow">
+    <meta name="generator" content="Publii Open-Source CMS for Static Site">
+    <link rel="alternate" type="application/atom+xml" href="https://POSYDON-code.github.io/feed.xml">
+    <link rel="alternate" type="application/json" href="https://POSYDON-code.github.io/feed.json">
+    <meta property="og:title" content="POSYDON">
+    <meta property="og:site_name" content="POSYDON">
+    <meta property="og:description" content="">
+    <meta property="og:url" content="https://POSYDON-code.github.io/">
+    <meta property="og:type" content="website">
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
+    <style>h1,h2,h3,h4,h5,h6,.btn,[type=button],[type=submit],button,.navbar .navbar__menu li,.navbar_mobile_sidebar .navbar__menu li,.feed__author,.post__tag,.post__share>a span,.post__nav-link>span,.footer{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"}body,h1,.h1,blockquote,.search__input,.author__name,.author__info>p,.feed__item h2,.post__nav-link{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"}</style>
+    <link rel="stylesheet" href="https://POSYDON-code.github.io/assets/css/style.css?v=cc87cb8806c844f0646558fe70d5c5d1">
+    <script type="application/ld+json">{
+      "@context":"http://schema.org",
+      "@type":"Organization",
+      "name":"POSYDON",
+      "url":"https://POSYDON-code.github.io/"
+    }
+    </script>
+    <script src="https://POSYDON-code.github.io/assets/js/ls.parent-fit.min.js?v=1c78585e2a70398fe95085061942fd37"></script>
+    <script async src="https://POSYDON-code.github.io/assets/js/lazysizes.min.js?v=149ff45fc6c2f13e892e438a58abb77f"></script>
+  </head>
+  <body>
+    <div class="site-container">
+      <header class="top" id="js-header">
+        <a class="logo" href="https://POSYDON-code.github.io/">POSYDON</a>
+        <div class="search">
+          <div class="search__overlay js-search-overlay">
+            <div class="search__overlay-inner">
+              <form action="https://POSYDON-code.github.io/search.html" class="search__form">
+                <input class="search__input js-search-input" type="search" name="q" placeholder="search..." autofocus="autofocus">
+              </form>
+              <button class="search__close js-search-close" aria-label="Close">Close</button>
+            </div>
+          </div>
+          <button class="search__btn js-search-btn" aria-label="Search">
+            <svg role="presentation" focusable="false">
+              <use xlink:href="https://POSYDON-code.github.io/assets/svg/svg-map.svg#search"/>
+            </svg>
+          </button>
+        </div>
+      </header>
+      <main>
+        <article class="post">
+          <div class="hero">
+            <header class="hero__content">
+              <div class="wrapper">
+                <h1>404</h1>
+                <p>Page not found</p>
+              </div>
+            </header>
+          </div>
+          <div class="wrapper post__entry">
+            <p>
+              The page you were looking for appears to have been moved, deleted or does not exist. You could go back to where you were or head straight to our home page.
+            </p>
+            <p>
+              <svg width="1.041em" height="0.416em" aria-hidden="true">
+                <use xlink:href="https://POSYDON-code.github.io/assets/svg/svg-map.svg#arrow-prev"/>
+              </svg>
+              <a href="https://POSYDON-code.github.io/" class="readmore">Go home</a>
+            </p>
+          </div>
+        </article>
+      </main>
+      <footer class="footer">
+        <div class="footer__copyright">
+          Powered by <a href="https://getpublii.com" target="_blank" rel="nofollow noopener noreferrer">Publii Static CMS</a>
+        </div>
+        <button class="footer__bttop js-footer__bttop" aria-label="Back to top">
+          <svg>
+            <title>
+              Back to top
+            </title>
+            <use xlink:href="https://POSYDON-code.github.io/assets/svg/svg-map.svg#toparrow"/>
+          </svg>
+        </button>
+      </footer>
+    </div>
+    <script>
+      window.publiiThemeMenuConfig = {
+        mobileMenuMode: 'sidebar',
+        animationSpeed: 300,
+        submenuWidth: 'auto',
+        doubleClickTime: 500,
+        mobileMenuExpandableSubmenus: true,
+        relatedContainerForOverlayMenuSelector: '.top',
+      };
+    </script>
+    <script defer="defer" src="https://POSYDON-code.github.io/assets/js/scripts.min.js?v=f56b13ba141d95ea2a0b7aab75ca9528"></script>
+    <script>
+      var lazyFeaturedImage=function lazyFeaturedImage(){
+        var b=document.querySelectorAll(".hero__image-img");
+        for(var a=0;a<b.length;a++){
+          var c=b[a];
+          c.addEventListener(
+            "lazyloaded",function(f){
+              var d=f.target.parentNode;
+              d.classList.add("hero__image--overlay")
+            }
+          )
+        }
+      };
+      lazyFeaturedImage();
+    </script>
+  </body>
 </html>

--- a/404.html
+++ b/404.html
@@ -1,8 +1,114 @@
-<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta http-equiv="X-UA-Compatible" content="IE=edge"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Error 404 - PSyLib</title><meta name="robots" content="noindex, follow"><meta name="generator" content="Publii Open-Source CMS for Static Site"><link rel="alternate" type="application/atom+xml" href="https://PSyLib.github.io/feed.xml"><link rel="alternate" type="application/json" href="https://PSyLib.github.io/feed.json"><meta property="og:title" content="PSyLib"><meta property="og:site_name" content="PSyLib"><meta property="og:description" content=""><meta property="og:url" content="https://PSyLib.github.io/"><meta property="og:type" content="website"><link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin><style>h1,h2,h3,h4,h5,h6,.btn,[type=button],[type=submit],button,.navbar .navbar__menu li,.navbar_mobile_sidebar .navbar__menu li,.feed__author,.post__tag,.post__share>a span,.post__nav-link>span,.footer{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"}body,h1,.h1,blockquote,.search__input,.author__name,.author__info>p,.feed__item h2,.post__nav-link{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"}</style><link rel="stylesheet" href="https://PSyLib.github.io/assets/css/style.css?v=cc87cb8806c844f0646558fe70d5c5d1"><script type="application/ld+json">{"@context":"http://schema.org","@type":"Organization","name":"PSyLib","url":"https://PSyLib.github.io/"}</script><script src="https://PSyLib.github.io/assets/js/ls.parent-fit.min.js?v=1c78585e2a70398fe95085061942fd37"></script><script async src="https://PSyLib.github.io/assets/js/lazysizes.min.js?v=149ff45fc6c2f13e892e438a58abb77f"></script></head><body><div class="site-container"><header class="top" id="js-header"><a class="logo" href="https://PSyLib.github.io/">PSyLib</a><div class="search"><div class="search__overlay js-search-overlay"><div class="search__overlay-inner"><form action="https://PSyLib.github.io/search.html" class="search__form"><input class="search__input js-search-input" type="search" name="q" placeholder="search..." autofocus="autofocus"></form><button class="search__close js-search-close" aria-label="Close">Close</button></div></div><button class="search__btn js-search-btn" aria-label="Search"><svg role="presentation" focusable="false"><use xlink:href="https://PSyLib.github.io/assets/svg/svg-map.svg#search"/></svg></button></div></header><main><article class="post"><div class="hero"><header class="hero__content"><div class="wrapper"><h1>404</h1><p>Page not found</p></div></header></div><div class="wrapper post__entry"><p>The page you were looking for appears to have been moved, deleted or does not exist. You could go back to where you were or head straight to our home page.</p><p><svg width="1.041em" height="0.416em" aria-hidden="true"><use xlink:href="https://PSyLib.github.io/assets/svg/svg-map.svg#arrow-prev"/></svg> <a href="https://PSyLib.github.io/" class="readmore">Go home</a></p></div></article></main><footer class="footer"><div class="footer__copyright">Powered by <a href="https://getpublii.com" target="_blank" rel="nofollow noopener noreferrer">Publii Static CMS</a></div><button class="footer__bttop js-footer__bttop" aria-label="Back to top"><svg><title>Back to top</title><use xlink:href="https://PSyLib.github.io/assets/svg/svg-map.svg#toparrow"/></svg></button></footer></div><script>window.publiiThemeMenuConfig = {    
-        mobileMenuMode: 'sidebar',
-        animationSpeed: 300,
-        submenuWidth: 'auto',
-        doubleClickTime: 500,
-        mobileMenuExpandableSubmenus: true, 
-        relatedContainerForOverlayMenuSelector: '.top',
-   };</script><script defer="defer" src="https://PSyLib.github.io/assets/js/scripts.min.js?v=f56b13ba141d95ea2a0b7aab75ca9528"></script><script>var lazyFeaturedImage=function lazyFeaturedImage(){var b=document.querySelectorAll(".hero__image-img");for(var a=0;a<b.length;a++){var c=b[a];c.addEventListener("lazyloaded",function(f){var d=f.target.parentNode;d.classList.add("hero__image--overlay")})}};lazyFeaturedImage();</script></body></html>
+<!DOCTYPE html>
+<html lang="en">
+        <head><meta charset="utf-8">
+                <meta http-equiv="X-UA-Compatible" content="IE=edge">
+                <meta name="viewport" content="width=device-width,initial-scale=1">
+                <title>
+                        Error 404 - POSYDON
+                </title>
+                <meta name="robots" content="noindex, follow">
+                <meta name="generator" content="Publii Open-Source CMS for Static Site">
+                <link rel="alternate" type="application/atom+xml" href="https://POSYDON-code.github.io/feed.xml">
+                <link rel="alternate" type="application/json" href="https://POSYDON-code.github.io/feed.json">
+                <meta property="og:title" content="POSYDON">
+                <meta property="og:site_name" content="POSYDON">
+                <meta property="og:description" content="">
+                <meta property="og:url" content="https://POSYDON-code.github.io/">
+                <meta property="og:type" content="website">
+                <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
+                <style>h1,h2,h3,h4,h5,h6,.btn,[type=button],[type=submit],button,.navbar .navbar__menu li,.navbar_mobile_sidebar .navbar__menu li,.feed__author,.post__tag,.post__share>a span,.post__nav-link>span,.footer{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"}body,h1,.h1,blockquote,.search__input,.author__name,.author__info>p,.feed__item h2,.post__nav-link{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"}</style>
+                <link rel="stylesheet" href="https://POSYDON-code.github.io/assets/css/style.css?v=cc87cb8806c844f0646558fe70d5c5d1">
+                <script type="application/ld+json">
+                        {"@context":"http://schema.org",
+                         "@type":"Organization",
+                         "name":"POSYDON",
+                         "url":"https://POSYDON-code.github.io/"
+                        }
+                </script>
+                <script src="https://POSYDON-code.github.io/assets/js/ls.parent-fit.min.js?v=1c78585e2a70398fe95085061942fd37"></script>
+                <script async src="https://POSYDON-code.github.io/assets/js/lazysizes.min.js?v=149ff45fc6c2f13e892e438a58abb77f"></script>
+        </head>
+        <body>
+                <div class="site-container">
+                        <header class="top" id="js-header">
+                                <a class="logo" href="https://POSYDON-code.github.io/">POSYDON</a>
+                                <div class="search">
+                                        <div class="search__overlay js-search-overlay">
+                                                <div class="search__overlay-inner">
+                                                        <form action="https://POSYDON-code.github.io/search.html" class="search__form">
+                                                                <input class="search__input js-search-input" type="search" name="q" placeholder="search..." autofocus="autofocus">
+                                                        </form>
+                                                        <button class="search__close js-search-close" aria-label="Close">Close</button>
+                                                </div>
+                                        </div>
+                                        <button class="search__btn js-search-btn" aria-label="Search">
+                                                <svg role="presentation" focusable="false">
+                                                        <use xlink:href="https://POSYDON-code.github.io/assets/svg/svg-map.svg#search"/>
+                                                </svg>
+                                        </button>
+                                </div>
+                        </header>
+                        <main>
+                                <article class="post">
+                                        <div class="hero">
+                                                <header class="hero__content">
+                                                        <div class="wrapper">
+                                                                <h1>404</h1>
+                                                                <p>Page not found</p>
+                                                        </div>
+                                                </header>
+                                        </div>
+                                        <div class="wrapper post__entry">
+                                                <p>
+                                                        The page you were looking for appears to have been moved, deleted or does not exist. You could go back to where you were or head straight to our home page.</p>
+                                                <p>
+                                                        <svg width="1.041em" height="0.416em" aria-hidden="true">
+                                                                <use xlink:href="https://POSYDON-code.github.io/assets/svg/svg-map.svg#arrow-prev"/>
+                                                        </svg>
+                                                        <a href="https://POSYDON-code.github.io/" class="readmore">Go home</a>
+                                                </p>
+                                        </div>
+                                </article>
+                        </main>
+                        <footer class="footer">
+                                <div class="footer__copyright">
+                                        Powered by <a href="https://getpublii.com" target="_blank" rel="nofollow noopener noreferrer">Publii Static CMS</a>
+                                </div>
+                                <button class="footer__bttop js-footer__bttop" aria-label="Back to top">
+                                        <svg>
+                                                <title>
+                                                        Back to top
+                                                </title>
+                                                <use xlink:href="https://POSYDON-code.github.io/assets/svg/svg-map.svg#toparrow"/>
+                                        </svg>
+                                </button>
+                        </footer>
+                </div>
+                <script>
+                        window.publiiThemeMenuConfig = {
+                                mobileMenuMode: 'sidebar',
+                                animationSpeed: 300,
+                                submenuWidth: 'auto',
+                                doubleClickTime: 500,
+                                mobileMenuExpandableSubmenus: true,
+                                relatedContainerForOverlayMenuSelector: '.top',
+                        };
+                </script>
+                <script defer="defer" src="https://POSYDON-code.github.io/assets/js/scripts.min.js?v=f56b13ba141d95ea2a0b7aab75ca9528"></script>
+                <script>
+                        var lazyFeaturedImage=function lazyFeaturedImage(){
+                                var b=document.querySelectorAll(".hero__image-img");
+                                for(var a=0;a<b.length;a++){
+                                        var c=b[a];
+                                        c.addEventListener(
+                                                "lazyloaded",function(f){
+                                                        var d=f.target.parentNode;
+                                                        d.classList.add("hero__image--overlay")
+                                                }
+                                        )
+                                }
+                        };
+                        lazyFeaturedImage();
+                </script>
+        </body>
+</html>

--- a/feed.json
+++ b/feed.json
@@ -1,0 +1,13 @@
+{
+    "version": "https://jsonfeed.org/version/1",
+    "title": "POSYDON",
+    "description": "",
+    "home_page_url": "https://POSYDON-code.github.io",
+    "feed_url": "https://POSYDON-code.github.io/feed.json",
+    "user_comment": "",
+    "author": {
+        "name": "Tassos Fragos"
+    },
+    "items": [
+    ]
+}

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title>POSYDON</title>
+    <link href="https://POSYDON-code.github.io/feed.xml" rel="self" />
+    <link href="https://POSYDON-code.github.io" />
+    <updated>1970-01-01T01:00:00+01:00</updated>
+    <author>
+        <name>Tassos Fragos</name>
+    </author>
+    <id>https://POSYDON-code.github.io</id>
+
+</feed>

--- a/search.html
+++ b/search.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>
+      Search - POSYDON
+    </title>
+    <meta name="robots" content="noindex, follow">
+    <meta name="generator" content="Publii Open-Source CMS for Static Site">
+    <link rel="alternate" type="application/atom+xml" href="https://POSYDON-code.github.io/feed.xml">
+    <link rel="alternate" type="application/json" href="https://POSYDON-code.github.io/feed.json">
+    <meta property="og:title" content="POSYDON">
+    <meta property="og:site_name" content="POSYDON">
+    <meta property="og:description" content="">
+    <meta property="og:url" content="https://POSYDON-code.github.io/">
+    <meta property="og:type" content="website">
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
+    <style>h1,h2,h3,h4,h5,h6,.btn,[type=button],[type=submit],button,.navbar .navbar__menu li,.navbar_mobile_sidebar .navbar__menu li,.feed__author,.post__tag,.post__share>a span,.post__nav-link>span,.footer{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"}body,h1,.h1,blockquote,.search__input,.author__name,.author__info>p,.feed__item h2,.post__nav-link{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"}</style>
+    <link rel="stylesheet" href="https://POSYDON-code.github.io/assets/css/style.css?v=cc87cb8806c844f0646558fe70d5c5d1">
+    <script type="application/ld+json">{"@context":"http://schema.org",
+      "@type":"Organization",
+      "name":"POSYDON",
+      "url":"https://POSYDON-code.github.io/"
+      }
+    </script>
+    <script src="https://POSYDON-code.github.io/assets/js/ls.parent-fit.min.js?v=1c78585e2a70398fe95085061942fd37"></script>
+    <script async src="https://POSYDON-code.github.io/assets/js/lazysizes.min.js?v=149ff45fc6c2f13e892e438a58abb77f"></script>
+  </head>
+  <body>
+    <div class="site-container">
+      <header class="top" id="js-header">
+        <a class="logo" href="https://POSYDON-code.github.io/">POSYDON</a>
+        <div class="search">
+          <div class="search__overlay js-search-overlay">
+            <div class="search__overlay-inner">
+              <form action="https://POSYDON-code.github.io/search.html" class="search__form">
+                <input class="search__input js-search-input" type="search" name="q" placeholder="search..." autofocus="autofocus">
+              </form>
+              <button class="search__close js-search-close" aria-label="Close">Close</button>
+            </div>
+          </div>
+          <button class="search__btn js-search-btn" aria-label="Search">
+            <svg role="presentation" focusable="false">
+              <use xlink:href="https://POSYDON-code.github.io/assets/svg/svg-map.svg#search"/>
+            </svg>
+          </button>
+        </div>
+      </header>
+      <main>
+        <article class="post search-page">
+          <div class="hero">
+            <header class="hero__content">
+              <div class="wrapper">
+                <h1>Search</h1>
+              </div>
+            </header>
+          </div>
+          <div class="wrapper post__entry">
+            <form action="https://POSYDON-code.github.io/search.html" class="search-page__form">
+              <input type="search" name="q" placeholder="search..." class="search-page__input">
+              <button type="submit">Submit</button>
+            </form>
+            <script>
+              (function () {
+                var cx = '';
+                var gcse = document.createElement('script');
+                gcse.type  = 'text/javascript';
+                gcse.async = true;
+                gcse.src   = 'https://cse.google.com/cse.js?cx=' + cx;
+                var s = document.getElementsByTagName('script')[0];
+                s.parentNode.insertBefore(gcse, s);
+                }
+              )();
+            </script>
+            <gcse:searchresults-only></gcse:searchresults-only>
+          </div>
+        </article>
+      </main>
+      <footer class="footer">
+        <div class="footer__copyright">
+          Powered by <a href="https://getpublii.com" target="_blank" rel="nofollow noopener noreferrer">Publii Static CMS</a>
+        </div>
+        <button class="footer__bttop js-footer__bttop" aria-label="Back to top">
+          <svg>
+            <title>
+              Back to top
+            </title>
+            <use xlink:href="https://POSYDON-code.github.io/assets/svg/svg-map.svg#toparrow"/>
+          </svg>
+        </button>
+      </footer>
+    </div>
+    <script>
+      window.publiiThemeMenuConfig = {    
+        mobileMenuMode: 'sidebar',
+        animationSpeed: 300,
+        submenuWidth: 'auto',
+        doubleClickTime: 500,
+        mobileMenuExpandableSubmenus: true,
+        relatedContainerForOverlayMenuSelector: '.top',
+      };
+    </script>
+    <script defer="defer" src="https://POSYDON-code.github.io/assets/js/scripts.min.js?v=f56b13ba141d95ea2a0b7aab75ca9528"></script>
+    <script>
+      var lazyFeaturedImage=function lazyFeaturedImage(){
+        var b=document.querySelectorAll(".hero__image-img");
+        for(var a=0;a<b.length;a++){
+          var c=b[a];
+          c.addEventListener(
+            "lazyloaded",function(f){
+              var d=f.target.parentNode;
+              d.classList.add("hero__image--overlay")
+            }
+          )
+        }
+      };
+      lazyFeaturedImage();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Update the error page and pages linked/loaded there (you can click on the links to see the github preview of the files):

- [x] update [404.html](https://htmlpreview.github.io/?https://github.com/POSYDON-code/POSYDON-code.github.io/blob/matthias_error_page/404.html)
  - [x] duplicate and update [feed.json](https://htmlpreview.github.io/?https://github.com/POSYDON-code/POSYDON-code.github.io/blob/matthias_error_page/feed.json)
  - [x] duplicate and update [feed.xml](https://htmlpreview.github.io/?https://github.com/POSYDON-code/POSYDON-code.github.io/blob/matthias_error_page/feed.xml)
  - [x] duplicate and update [search.html](https://htmlpreview.github.io/?https://github.com/POSYDON-code/POSYDON-code.github.io/blob/matthias_error_page/search.html)

The duplicated files are taken from [prev](https://github.com/POSYDON-code/POSYDON-code.github.io/tree/master/prev)
For reference, see issue #44 