### PR TITLE
Correct zenodo link

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,20 +97,22 @@
 
       .carousel-control-prev, .carousel-control-next {
         position: absolute;
-        top:50%;
-        transform:TranslateY(-50%);
+        /*top:50%;
+        transform:TranslateY(-50%);*/
+	width: 5%;
+	min-width: 60px;
       }
 
       .carousel-control-prev{
         /*left: 5% !important;*/
         right: auto;
-        left: -70px;
+        left: 0px;
       }
 
       .carousel-control-next{
         /*right: 5% !important;*/
         left:auto;
-        right:-70px;
+        right: 0px;
       }
 
       /*.carousel-control-next-icon, .carousel-control-prev-icon {

--- a/index.html
+++ b/index.html
@@ -313,10 +313,10 @@
         </div>
       </div> 
       <!-- Left and right controls -->
-      <a class="carousel-control-prev carousel-controls" href="#demo" data-slide="prev">
+      <a class="carousel-controls carousel-control-prev" href="#demo" data-slide="prev">
         <span class="carousel-control-prev-icon"></span>
       </a>
-      <a class="carousel-control-next carousel-controls" href="#demo" data-slide="next">
+      <a class="carousel-controls carousel-control-next" href="#demo" data-slide="next">
         <span class="carousel-control-next-icon"></span>
       </a>
     </div>

--- a/index.html
+++ b/index.html
@@ -96,11 +96,11 @@
       }
 
       .carousel-controls {
-        position: absolute;
+        position: absolute !important;
         /*top:50%;
         transform:TranslateY(-50%);*/
-        width: 5%;
-        min-width: 60px;
+        width: 5% !important;
+        min-width: 60px !important;
       }
 
       .carousel-control-prev{

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
         position:relative;
       }
 
-      .carousel-control-prev, .carousel-control-next {
+      .carousel-controls {
         position: absolute;
         /*top:50%;
         transform:TranslateY(-50%);*/
@@ -313,10 +313,10 @@
         </div>
       </div> 
       <!-- Left and right controls -->
-      <a class="carousel-control-prev" href="#demo" data-slide="prev">
+      <a class="carousel-control-prev carousel-controls" href="#demo" data-slide="prev">
         <span class="carousel-control-prev-icon"></span>
       </a>
-      <a class="carousel-control-next" href="#demo" data-slide="next">
+      <a class="carousel-control-next carousel-controls" href="#demo" data-slide="next">
         <span class="carousel-control-next-icon"></span>
       </a>
     </div>

--- a/index.html
+++ b/index.html
@@ -435,7 +435,7 @@
             <!-- parent card body -->
             <div class="card-body" id="codeCard">
               <!-- parent card navigation content-->
-              <div class="tab-content" id="myTabContent">
+              <div class="tab-content" id="myTabContent" style="margin-left: -1.25rem;margin-right: -1.25rem;">
                 <!--first nav pane content-->
                 <div class="tab-pane fade show active" id="v2" role="tabpanel" aria-labelledby="v2-tab">
                   <!--start v2 card deck with links to docs, code, and data-->
@@ -500,7 +500,7 @@
                             <a class="dropdown-item" href="#">low mass res., 2 - 10<sup>-4</sup> <i>Z</i><sub>&odot;</sub> (coming soon!)</a>
                             <div class="dropdown-divider"></div>
                             <a class="dropdown-item" href="https://zenodo.org/records/14205146", target="_blank">high mass res., <i>Z</i><sub>&odot;</sub></a>
-                            <a class="dropdown-item" href="https://zenodo.org/records/14205146", target="_blank">high mass res., <i>Z</i><sub>&odot;</sub>, w/ Edd. accretion</a>
+                            <a class="dropdown-item" href="https://zenodo.org/records/14216817", target="_blank">high mass res., <i>Z</i><sub>&odot;</sub>, w/ Edd. accretion</a>
                           </div>
                         </div>
                       </div>

--- a/index.html
+++ b/index.html
@@ -99,8 +99,8 @@
         position: absolute;
         /*top:50%;
         transform:TranslateY(-50%);*/
-	width: 5%;
-	min-width: 60px;
+        width: 5%;
+        min-width: 60px;
       }
 
       .carousel-control-prev{


### PR DESCRIPTION
- [x] correct zenodo link to super-Eddington accretion dataset
- [x] additionally, compensate padding to get the first three cards into one row
- [x] move carousel control buttons inside the page

You can check the github preview [here](https://htmlpreview.github.io/?https://github.com/POSYDON-code/POSYDON-code.github.io/blob/matthias_fix_zenodo/index.html)