### PR TITLE
Fix jquery-ui import

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <![endif]-->
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://code.jquery.com/ui/1.11.3/jquery-ui.js"></script>
+    <script src="https://code.jquery.com/ui/1.11.3/jquery-ui.js"></script>
     <script src="js/bootstrap.bundle.min.js"></script>
 	
     <style>


### PR DESCRIPTION
The site uses `https` protocol but `http` is currently used to import jquery ui here in the main `index.html`:

```
...
29    <script src="http://code.jquery.com/ui/1.11.3/jquery-ui.js"></script>
...
```

This causes a mixed content error and prevents certain functions from being recognized (namely the `effect` function currently used to highlight code cards). This is a quick fix to update the link to `https` to resolve the error.

