### PR TITLE
Fix initial page navbar highlight

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,8 +224,6 @@
 
       $(document).ready(function(){
 
-        var currentUrl = location.hash;
-
         // highlight appropriate navbar items on load or hashchange
         $(window).on('hashchange', function(event){
 

--- a/index.html
+++ b/index.html
@@ -202,7 +202,6 @@
         $('.navbar-nav a').each(function() {
 
           var linkUrl = $(this).attr('href');
-          console.log(linkUrl)
 
           if (currentUrl === linkUrl) {
             // Add 'active' class to parent <li>

--- a/index.html
+++ b/index.html
@@ -191,12 +191,18 @@
       function highlightActive(load=true) {
 
         // Get current page URL
-        var currentUrl = window.location.href.split('index.html')[1];
+        var currentUrl = location.hash;
+
+        // on initial page load the url directs to index.html, which leads to an initially empty string
+        if (currentUrl == "") {
+          currentUrl = "#"
+        }
 
         // Find the matching navbar item
         $('.navbar-nav a').each(function() {
 
           var linkUrl = $(this).attr('href');
+          console.log(linkUrl)
 
           if (currentUrl === linkUrl) {
             // Add 'active' class to parent <li>
@@ -217,6 +223,8 @@
       };
 
       $(document).ready(function(){
+
+        var currentUrl = location.hash;
 
         // highlight appropriate navbar items on load or hashchange
         $(window).on('hashchange', function(event){

--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
       function highlightActive(load=true) {
 
         // Get current page URL
-        var currentUrl = location.hash;
+        var currentUrl = window.location.hash;
 
         // on initial page load the url directs to index.html, which leads to an initially empty string
         if (currentUrl == "") {

--- a/team.html
+++ b/team.html
@@ -22,7 +22,7 @@
     <link href="css/bootstrap.min.css" rel="stylesheet" />
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://code.jquery.com/ui/1.11.3/jquery-ui.js"></script>
+    <script src="https://code.jquery.com/ui/1.11.3/jquery-ui.js"></script>
     <script src="js/bootstrap.min.js"></script>
 
     <style>    


### PR DESCRIPTION
The site doesn't highlight an active link on the navbar initially because of the URL structure. This adapts the javascript responsible for highlighting navbar links to catch this and will highlight the "Home" link on an initial page load.