### PR TITLE
Quick fix to school news announcement

### DIFF
--- a/pages/news.html
+++ b/pages/news.html
@@ -95,7 +95,7 @@
 
   <body>
     <ul class="list-group list-group-flush news-list">
-      <li class="list-group-item"><b>[January 22nd, 2025]</b> <b>Announcement:</b> We are happy to announce the <a href="https://posydon.org/school.html">first POSYDON summer school</a> in September 2025.</li>
+      <li class="list-group-item"><b>[January 22nd, 2025]</b> <b>Announcement:</b> We are happy to announce the <a href="https://posydon.org/school.html">first POSYDON school</a> in September 2025.</li>
       <li class="list-group-item"><b>[November 5th, 2024]</b> We posted on the <b><a href="https://arxiv.org/abs/2411.02586" target="_blank">arXiv</a></b> a paper presenting a method of binary stellar evolution track interpolation (Srivastava et al.)</li>
       <li class="list-group-item"><b>[November 4th, 2024]</b> We posted on the <b><a href="https://arxiv.org/abs/2411.02376" target="_blank">arXiv</a></b> the preprint version of the POSYDON v2.0 instrument paper (Andrews et al.). This describes the second version of our code and grids of simulated binaries </li>
       <li class="list-group-item"><b>[October 29th, 2024]</b> We posted on the <b><a href="http://arxiv.org/abs/2410.20415" target="_blank">arXiv</a></b> a paper utilizing POSYDON to investigate the impact of common-envelope efficiency and core-collapse supernova kicks on the black hole (BH) mass distribution of neutron star-BH (NSBH) mergers, and systems observed in the lower BH mass gap (Xing et al.)</li>	  

--- a/pages/news.html
+++ b/pages/news.html
@@ -95,7 +95,7 @@
 
   <body>
     <ul class="list-group list-group-flush news-list">
-      <li class="list-group-item"><b>[January 22nd, 2025]</b> <b>Announcement:</b> We are happy to announce the <a href="https://posydon.org/summer_school.html">first POSYDON summer school</a> in September 2025.</li>
+      <li class="list-group-item"><b>[January 22nd, 2025]</b> <b>Announcement:</b> We are happy to announce the <a href="https://posydon.org/school.html">first POSYDON summer school</a> in September 2025.</li>
       <li class="list-group-item"><b>[November 5th, 2024]</b> We posted on the <b><a href="https://arxiv.org/abs/2411.02586" target="_blank">arXiv</a></b> a paper presenting a method of binary stellar evolution track interpolation (Srivastava et al.)</li>
       <li class="list-group-item"><b>[November 4th, 2024]</b> We posted on the <b><a href="https://arxiv.org/abs/2411.02376" target="_blank">arXiv</a></b> the preprint version of the POSYDON v2.0 instrument paper (Andrews et al.). This describes the second version of our code and grids of simulated binaries </li>
       <li class="list-group-item"><b>[October 29th, 2024]</b> We posted on the <b><a href="http://arxiv.org/abs/2410.20415" target="_blank">arXiv</a></b> a paper utilizing POSYDON to investigate the impact of common-envelope efficiency and core-collapse supernova kicks on the black hole (BH) mass distribution of neutron star-BH (NSBH) mergers, and systems observed in the lower BH mass gap (Xing et al.)</li>	  

--- a/pages/news.html
+++ b/pages/news.html
@@ -95,6 +95,7 @@
 
   <body>
     <ul class="list-group list-group-flush news-list">
+      <li class="list-group-item"><b>[April 7th, 2025]</b> <b>Announcement:</b> The <a href="https://posydon.org/posydon-school-2025/#apply">registration</a> to the POSYDON school is now open. More details can be found on the <a href="https://posydon.org/posydon-school-2025">2025 school web page</a>.</li>
       <li class="list-group-item"><b>[January 22nd, 2025]</b> <b>Announcement:</b> We are happy to announce the <a href="https://posydon.org/school.html">first POSYDON school</a> in September 2025.</li>
       <li class="list-group-item"><b>[November 5th, 2024]</b> We posted on the <b><a href="https://arxiv.org/abs/2411.02586" target="_blank">arXiv</a></b> a paper presenting a method of binary stellar evolution track interpolation (Srivastava et al.)</li>
       <li class="list-group-item"><b>[November 4th, 2024]</b> We posted on the <b><a href="https://arxiv.org/abs/2411.02376" target="_blank">arXiv</a></b> the preprint version of the POSYDON v2.0 instrument paper (Andrews et al.). This describes the second version of our code and grids of simulated binaries </li>

--- a/pages/news.html
+++ b/pages/news.html
@@ -95,7 +95,7 @@
 
   <body>
     <ul class="list-group list-group-flush news-list">
-      <li class="list-group-item"><b>[April 7th, 2025]</b> <b>Announcement:</b> The <a href="https://posydon.org/posydon-school-2025/#apply">registration</a> to the POSYDON school is now open. More details can be found on the <a href="https://posydon.org/posydon-school-2025">2025 school web page</a>.</li>
+      <li class="list-group-item"><b>[April 7th, 2025]</b> <b>Announcement:</b> The <a href="https://posydon.org/posydon-school-2025/#apply">registration</a> for the POSYDON school is now open. More details can be found on the <a href="https://posydon.org/posydon-school-2025">2025 school web page</a>.</li>
       <li class="list-group-item"><b>[January 22nd, 2025]</b> <b>Announcement:</b> We are happy to announce the <a href="https://posydon.org/school.html">first POSYDON school</a> in September 2025.</li>
       <li class="list-group-item"><b>[November 5th, 2024]</b> We posted on the <b><a href="https://arxiv.org/abs/2411.02586" target="_blank">arXiv</a></b> a paper presenting a method of binary stellar evolution track interpolation (Srivastava et al.)</li>
       <li class="list-group-item"><b>[November 4th, 2024]</b> We posted on the <b><a href="https://arxiv.org/abs/2411.02376" target="_blank">arXiv</a></b> the preprint version of the POSYDON v2.0 instrument paper (Andrews et al.). This describes the second version of our code and grids of simulated binaries </li>


### PR DESCRIPTION
The News item announcing the Summer school navigates to the old summer_school.html, and this corrects it to navigate to the new school.html. It also edits the text so that it does not refer to it as a Summer School, rather it is referred to just as School.