### PR TITLE
Fix news update Github action issue parser

### DIFF
--- a/.github/workflows/publish_news.yml
+++ b/.github/workflows/publish_news.yml
@@ -24,13 +24,16 @@ jobs:
 
       - name: Update news.json using Python
         shell: python
+        env:
+          FORM_DATA: ${{ steps.parse.outputs.jsonString }}
         run: |
           import json
+          import os
           import re
           from datetime import datetime
 
           # 1. Load parsed form data
-          form_data = json.loads('${{ steps.parse.outputs.json_string }}')
+          form_data = json.loads(os.environ["FORM_DATA"])
           
           new_entry = {
               "type": "Announcement" if "Announcement" in form_data.get("entry_type", "") else "Paper",


### PR DESCRIPTION
Apparently the issue parser `stefanbuck/github-issue-parser@v3` uses the following to parse Github issues, .e.g,:

```
steps.parse.outputs.jsonString
```

whereas before we had

```
steps.parse.outputs.json_string
```

Hopefully this fixes the Github action errror yielding:

```python
Traceback (most recent call last):
  File "/home/runner/work/_temp/6cc7e173-7cbb-4e91-8ab3-8453db7ef314.py", line 6, in <module>
    form_data = json.loads('')
                ^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```